### PR TITLE
Remove the bucket contents listing optimization

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -12,8 +12,6 @@ AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-east-1}
 
 s3_bucket="${BUILDKITE_PLUGIN_S3_SECRETS_BUCKET:-}"
 s3_bucket_prefix="${BUILDKITE_PLUGIN_S3_SECRETS_BUCKET_PREFIX:-$BUILDKITE_PIPELINE_SLUG}"
-s3_bucket_listable=
-ls_output=
 
 if [[ -n "$s3_bucket" ]] ; then
   echo "~~~ Downloading secrets from :s3: $s3_bucket" >&2;
@@ -21,15 +19,6 @@ if [[ -n "$s3_bucket" ]] ; then
   if ! s3_bucket_exists "$s3_bucket" ; then
     echo "+++ :warning: Bucket $s3_bucket doesn't exist" >&2;
     exit 1
-  fi
-
-  echo "Attempting to list keys in s3 bucket $s3_bucket" >&2;
-  if ls_output="$(s3_list "$s3_bucket")" ; then
-    s3_bucket_listable=1
-    s3_bucket_list=($ls_output)
-    echo "Found ${#s3_bucket_list[@]} keys in the bucket"
-  else
-    echo "Wasn't able to list keys, so will try individual head-object calls"
   fi
 
   ssh_key_paths=(
@@ -41,7 +30,7 @@ if [[ -n "$s3_bucket" ]] ; then
 
   for key in ${ssh_key_paths[*]} ; do
     echo "Checking ${key}" >&2
-    if has_secrets_key "$key" "$s3_bucket_listable" ; then
+    if s3_exists "$s3_bucket" "$key" ; then
       echo "Found ${key}, downloading" >&2;
       if ! ssh_key=$(s3_download "${s3_bucket}" "$key") ; then
         echo "+++ :warning: Failed to download ssh-key $key" >&2;
@@ -68,7 +57,7 @@ if [[ -n "$s3_bucket" ]] ; then
   env_before="$(env | sort)"
 
   for key in ${env_paths[*]} ; do
-    if has_secrets_key "$key" "$s3_bucket_listable" ; then
+    if s3_exists "$s3_bucket" "$key" ; then
       echo "Downloading env file from ${key}" >&2;
       if ! envscript=$(s3_download "${s3_bucket}" "$key") ; then
         echo "+++ :warning: Failed to download env from $key" >&2;
@@ -89,7 +78,7 @@ if [[ -n "$s3_bucket" ]] ; then
   git_credentials=()
 
   for key in ${git_credentials_paths[*]} ; do
-    if has_secrets_key "$key" ; then
+    if s3_exists "$s3_bucket" "$key" ; then
       echo "Adding git-credentials in $key as a credential helper" >&2;
       git_credentials+=("'credential.helper=$basedir/git-credential-s3-secrets ${s3_bucket} ${key}'")
     fi

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -1,14 +1,5 @@
 #!/bin/bash
 
-s3_list() {
-  local bucket="$1"
-  local aws_s3_args=("--region=$AWS_DEFAULT_REGION")
-
-  if ! aws s3 ls "${aws_s3_args[@]}" --recursive "s3://${bucket}" ; then
-    return 1
-  fi | awk '{print $4}'
-}
-
 s3_exists() {
   local bucket="$1"
   local key="$2"
@@ -24,22 +15,6 @@ s3_bucket_exists() {
   if aws s3api head-bucket --bucket "$bucket" 2>&1 | grep -q "Not Found" ; then
     return 1
   fi
-}
-
-has_secrets_key() {
-  local key="$1"
-  local has_list="${2:-}"
-
-  if [[ -n "$has_list" && ${#s3_bucket_list[@]} -gt 0 ]] ; then
-    for object in "${s3_bucket_list[@]}" ; do
-      if [[ "$object" == "$key" ]] ; then
-        return 0
-      fi
-    done
-    return 1
-  fi
-
-  s3_exists "$s3_bucket" "$key"
 }
 
 s3_download() {

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -20,43 +20,10 @@ generate_file_list() {
   export BUILDKITE_PLUGIN_S3_SECRETS_DUMP_ENV=true
   export BUILDKITE_PIPELINE_SLUG=test
 
-  stub ssh-agent "-s : echo export SSH_AGENT_PID=224;"
-
-  stub aws \
-    "s3api head-bucket --bucket my_secrets_bucket : exit 0" \
-    "s3 ls --region=us-east-1 --recursive s3://my_secrets_bucket : echo -e '2013-09-02 21:37:53\t10 env\n2013-09-02 21:32:57\t23 private_ssh_key\n2013-09-02 21:32:58\t41 test/private_ssh_key\n'" \
-    "s3 cp --quiet --region=us-east-1 --sse aws:kms s3://my_secrets_bucket/test/private_ssh_key /dev/stdout : echo secret material" \
-    "s3 cp --quiet --region=us-east-1 --sse aws:kms s3://my_secrets_bucket/private_ssh_key /dev/stdout : echo secret material" \
-    "s3 cp --quiet --region=us-east-1 --sse aws:kms s3://my_secrets_bucket/env /dev/stdout : echo SECRET=24" \
-    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key git-credentials : exit 1" \
-    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key test/git-credentials : exit 1"
-
-  stub ssh-add \
-    "echo added ssh key 1" \
-    "echo added ssh key 2"
-
-  run bash -c "$PWD/hooks/environment && $PWD/hooks/pre-exit"
-
-  assert_success
-  assert_output --partial "added ssh key 1"
-  assert_output --partial "added ssh key 2"
-  assert_output --partial "SECRET=24"
-
-  unstub ssh-agent
-  unstub ssh-add
-  unstub aws
-}
-
-@test "Load env file from s3 bucket (not listable)" {
-  export BUILDKITE_PLUGIN_S3_SECRETS_BUCKET=my_secrets_bucket
-  export BUILDKITE_PLUGIN_S3_SECRETS_DUMP_ENV=true
-  export BUILDKITE_PIPELINE_SLUG=test
-
   stub ssh-agent "-s : echo export SSH_AGENT_PID=93799"
 
   stub aws \
     "s3api head-bucket --bucket my_secrets_bucket : echo Forbidden; exit 0" \
-    "s3 ls --region=us-east-1 --recursive s3://my_secrets_bucket : exit 1" \
     "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key test/private_ssh_key : exit 1" \
     "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key test/id_rsa_github : exit 1" \
     "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key private_ssh_key : exit 0" \
@@ -85,7 +52,7 @@ generate_file_list() {
   unstub aws
 }
 
-@test "Load git-credentials from bucket into GIT_CONFIG_PARAMETERS (not listable)" {
+@test "Load git-credentials from bucket into GIT_CONFIG_PARAMETERS" {
   export BUILDKITE_PLUGIN_S3_SECRETS_BUCKET=my_secrets_bucket
   export BUILDKITE_PLUGIN_S3_SECRETS_DUMP_ENV=true
   export BUILDKITE_PIPELINE_SLUG=test
@@ -93,7 +60,6 @@ generate_file_list() {
 
   stub aws \
     "s3api head-bucket --bucket my_secrets_bucket : echo Forbidden; exit 0" \
-    "s3 ls --region=us-east-1 --recursive s3://my_secrets_bucket : exit 1" \
     "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key test/private_ssh_key : exit 1" \
     "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key test/id_rsa_github : exit 1" \
     "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key private_ssh_key : exit 1" \


### PR DESCRIPTION
The optimisation where a bucket list is used rather than trying individual keys really fails on large buckets. At this stage it hurts more than it helps and should be removed. 

Fixes #6.