### PR TITLE
Changed output from '/dev/stdout' to '-'

### DIFF
--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -26,7 +26,7 @@ s3_download() {
     aws_s3_args+=("--sse" "aws:kms")
   fi
 
-  if ! aws s3 cp "${aws_s3_args[@]}" "s3://$1/$2" /dev/stdout ; then
+  if ! aws s3 cp "${aws_s3_args[@]}" "s3://$1/$2" - ; then
     exit 1
   fi
 }


### PR DESCRIPTION
Hi guys,

Running the plugin thought Git for Windows bash interpreter fails with a '/dev/stdout' redirect so I have changed this to a more conventional '-' which tests fine in Windows.

Regards,
Mark.