### PR TITLE
Replaced '/dev/stdout' with '-' for GfW Bash

### DIFF
--- a/git-credential-s3-secrets
+++ b/git-credential-s3-secrets
@@ -61,7 +61,7 @@ s3_download() {
     aws_s3_args+=("--sse" "aws:kms")
   fi
 
-  if ! aws s3 cp "${aws_s3_args[@]}" "s3://$1/$2" /dev/stdout ; then
+  if ! aws s3 cp "${aws_s3_args[@]}" "s3://$1/$2" - ; then
     echo "Failed to download s3://$bucket/$key" >&2
     exit 1
   fi


### PR DESCRIPTION
Hi guys,

Found another Git for Windows Bash-ism which breaks redirect to stdout. I've updated the code for this and tested against my Windows agent. Works a charm.

Mark.